### PR TITLE
Downgrade python dependencies for Ubuntu bionic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.19.5
 pandas>=1.1.5
-PyQt5==5.15.4
+PyQt5==5.14.0
 matplotlib==3.4.1
 seaborn==0.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy>=1.20.1
-pandas>=1.2.3
+numpy>=1.19.5
+pandas>=1.1.5
 PyQt5==5.15.4
 matplotlib==3.4.1
 seaborn==0.11.1


### PR DESCRIPTION
**Problem Description**
This PR downgrades some of the dependency requirements so that it can also be used in Ubuntu Bionic.

**Additional context**
Still fails for pyQT
```
pip3 install -r Tools/parametric_model/visual_dataframe_selector/requirements.txt
Collecting numpy>=1.19.5 (from -r Tools/parametric_model/visual_dataframe_selector/requirements.txt (line 1))
  Using cached https://files.pythonhosted.org/packages/45/b2/6c7545bb7a38754d63048c7696804a0d947328125d81bf12beaa692c3ae3/numpy-1.19.5-cp36-cp36m-manylinux1_x86_64.whl
Collecting pandas>=1.1.5 (from -r Tools/parametric_model/visual_dataframe_selector/requirements.txt (line 2))
  Using cached https://files.pythonhosted.org/packages/c3/e2/00cacecafbab071c787019f00ad84ca3185952f6bb9bca9550ed83870d4d/pandas-1.1.5-cp36-cp36m-manylinux1_x86_64.whl
Collecting PyQt5==5.15.4 (from -r Tools/parametric_model/visual_dataframe_selector/requirements.txt (line 3))
  Using cached https://files.pythonhosted.org/packages/8e/a4/d5e4bf99dd50134c88b95e926d7b81aad2473b47fde5e3e4eac2c69a8942/PyQt5-5.15.4.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/usr/lib/python3.6/tokenize.py", line 452, in open
        buffer = _builtin_open(filename, 'rb')
    FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pip-build-gbdx075_/PyQt5/setup.py'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-gbdx075_/PyQt5/
```