### PR TITLE
Fix depreachiated matplotlib features

### DIFF
--- a/src/main_window.py
+++ b/src/main_window.py
@@ -121,9 +121,9 @@ class MainWindow(QtWidgets.QMainWindow):
                 direction="horizontal",
                 minspan=1,
                 useblit=True,
-                span_stays=False,
                 button=[1],
-                rectprops={"facecolor": "green", "alpha": 0.3})
+                props={"facecolor": "green", "alpha": 0.3}
+                )
         return
 
     def update_hist_plot(self, df):


### PR DESCRIPTION
Enable the VDFS being run on matplotlib 3.7. span_stays and rectprops were depreciated in the meantime. 

- span_stays is false by default, so nothing changes there. 
- rectprops is now only called props. color and oppacity of the selection window stay the same. 