### PR TITLE
Enable running in separate qt app

### DIFF
--- a/data_selector.py
+++ b/data_selector.py
@@ -19,3 +19,11 @@ def select_visual_data(data_df, plot_config_dict):
     w = MainWindow(data_df, plot_config_dict)
     app.exec_()
     return w.cropped_data_df
+
+
+def select_visual_data_in_running_app(data_df, plot_config_dict, app):
+    w = MainWindow(data_df, plot_config_dict)
+    app.processEvents()  # Process events once before waiting
+    while w.isVisible():  # Loop until window is closed
+        app.processEvents()
+    return w.cropped_data_df

--- a/src/main_window.py
+++ b/src/main_window.py
@@ -123,7 +123,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 useblit=True,
                 button=[1],
                 props={"facecolor": "green", "alpha": 0.3}
-                )
+            )
         return
 
     def update_hist_plot(self, df):
@@ -151,7 +151,8 @@ class MainWindow(QtWidgets.QMainWindow):
         if selection_accepted:
             print("selection accepted and added: ", min_x_val, max_x_val)
             cropped_df["old_index"] = copy.deepcopy(cropped_df.index)
-            self.cropped_data_df = self.cropped_data_df.append(cropped_df)
+            self.cropped_data_df = pd.concat(
+                [self.cropped_data_df, cropped_df])
             self.cropped_data_df = self.cropped_data_df.reset_index(drop=True)
             self.save_csv_button.setEnabled(True)
 


### PR DESCRIPTION
added the function `select_visual_data_in_running_app` which can be called if the visual dataframe selector should be part of a bigger qt app. Calling this method will pause the other app until the data selection is complete. 