### PR TITLE
Add selection visualitation & architecture overhaul

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [2021] [Manuel Galliker]
+   Copyright [2021] [Manuel Yves Galliker]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,4 +1,4 @@
 Visual Pandas Cropper
 Copyright 2016 The Apache Software Foundation.
 
-This software was developed by Manuel Galliker (@manumerous, manuel.galliker@gmx.ch)
+This software was developed by Manuel Yves Galliker (@manumerous, manuel.galliker@gmx.ch)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Hereby the user can specify which columns are plotted in which subplot. Furtherm
 
 The user can subsequentially select different horizontal data windows via click and drag and he tool then automatically combines the visually selected sections into a new dataframe.
 
-![Screenshot from 2021-05-02 19-40-25](https://user-images.githubusercontent.com/18735094/116822371-c2f50a80-ab7e-11eb-9f92-37e368873ef9.png)
+![image](https://user-images.githubusercontent.com/18735094/222962489-43e218ac-fcd1-4343-a569-69893b1ed8c8.png)
+
 
 ## Install dependencies
 
@@ -31,7 +32,10 @@ python3 test_visual_dataframe_selector.py
 
 ## Use the Tool
 
-- Left click with your mouse and drag to define the desired horizontal window of the data to be selected
-- Confirm or cancel data selection
-- The view automatically resets to contain all data and you can select the next data snipplet.
-- Once you could select all desired horizontal data windows click "done selecting"
+- Left click with your mouse and drag to define the desired horizontal window of the data to be selected.
+  - The current selection distribution is now visualized in the histogram plot on the right.
+- Confirm or cancel data selection.
+  - The already selected data is now marked by a grey span in the plot on the left.
+  - The plot on the right contains now the histogram of all selected data.
+- repeat as many times as needed.
+- Once you could select all desired horizontal data windows click "Done selecting"

--- a/data_selector.py
+++ b/data_selector.py
@@ -1,5 +1,5 @@
-__author__ = "Manuel Galliker"
-__maintainer__ = "Manuel Galliker"
+__author__ = "Manuel Yves Galliker"
+__maintainer__ = "Manuel Yves Galliker"
 __license__ = "Apache-2.0"
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ numpy>=1.19.5
 pandas>=1.1.5
 PyQt5==5.14.0
 matplotlib>=3.3.4
-seaborn==0.11.1
+seaborn>=0.11.1
+overrides>=7.3.1

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,7 @@
 from .confirm_selection_window import ConfirmSelectionWindow
 from .mpl_widget import MplWidget
+from .dataframe_plot_widget import DataFramePlotWidget
+from .time_series_data_plot_widget import TimeSeriesDataPlotWidget
+from .histogram_plot_widget import HistogramPlotWidget
 from . import main_window
 from .main_window import MainWindow

--- a/src/confirm_selection_window.py
+++ b/src/confirm_selection_window.py
@@ -1,5 +1,5 @@
-__author__ = "Manuel Galliker"
-__maintainer__ = "Manuel Galliker"
+__author__ = "Manuel Yves Galliker"
+__maintainer__ = "Manuel Yves Galliker"
 __license__ = "Apache-2.0"
 
 from PyQt5 import QtCore

--- a/src/dataframe_plot_widget.py
+++ b/src/dataframe_plot_widget.py
@@ -1,0 +1,30 @@
+__author__ = "Manuel Yves Galliker"
+__maintainer__ = "Manuel Yves Galliker"
+__license__ = "Apache-2.0"
+
+try:
+    from src.mpl_widget import MplWidget
+except:
+    from visual_dataframe_selector.src.mpl_widget import MplWidget
+
+from abc import abstractmethod
+import pandas as pd
+import copy
+
+
+class DataFramePlotWidget(MplWidget):
+    def __init__(self, plot_config_dict, parentWindow):
+        self.plot_config_dict = copy.deepcopy(plot_config_dict)
+        self.x_axis_col = self.plot_config_dict["x_axis_col"]
+        self.plot_config_dict.pop("x_axis_col", None)
+
+        self.subplot_keys = list(self.plot_config_dict.keys())
+        self.subplot_count = len(self.subplot_keys)
+
+        super(DataFramePlotWidget, self).__init__(
+            parentWindow, self.subplot_count)
+
+    @abstractmethod
+    def plot(self, df: pd.DataFrame):
+        """ Visualize the data from df in each subplot according to the specified columns in self.plot_config_dict. """
+        pass

--- a/src/histogram_plot_widget.py
+++ b/src/histogram_plot_widget.py
@@ -1,0 +1,30 @@
+__author__ = "Manuel Yves Galliker"
+__maintainer__ = "Manuel Yves Galliker"
+__license__ = "Apache-2.0"
+
+try:
+    from src.dataframe_plot_widget import DataFramePlotWidget
+except:
+    from visual_dataframe_selector.src.dataframe_plot_widget import DataFramePlotWidget
+
+import seaborn as sns
+import pandas as pd
+from overrides import override
+
+
+class HistogramPlotWidget(DataFramePlotWidget):
+    def __init__(self, plot_config_dict: dict, parentWindow):
+        super(HistogramPlotWidget, self).__init__(
+            plot_config_dict, parentWindow)
+
+    @override
+    def plot(self, df: pd.DataFrame):
+        for i in range(self.subplot_count):
+            self.canvas.subplot_axes[i].clear()
+            subplot_key = self.subplot_keys[i]
+            subplot_topics_list = self.plot_config_dict[subplot_key]
+            sns.histplot(df[subplot_topics_list],
+                         ax=self.canvas.subplot_axes[i], stat="probability")
+
+        self.canvas.draw()
+        return

--- a/src/histogram_plot_widget.py
+++ b/src/histogram_plot_widget.py
@@ -28,3 +28,9 @@ class HistogramPlotWidget(DataFramePlotWidget):
 
         self.canvas.draw()
         return
+
+    def clear(self):
+        for i in range(self.subplot_count):
+            self.canvas.subplot_axes[i].clear()
+        self.canvas.draw()
+        return

--- a/src/main_window.py
+++ b/src/main_window.py
@@ -49,10 +49,6 @@ class MainWindow(QtWidgets.QMainWindow):
 
         master_layout = QtWidgets.QGridLayout()
 
-        text_label = QLabel(
-            "Select Data by clicking the left mouse button and dragging the cursor")
-        text_label.setFixedSize(600, 30)
-
         self.termination_button = QPushButton("Done selecting")
         self.termination_button.setFixedSize(150, 30)
         # connect signal
@@ -64,16 +60,18 @@ class MainWindow(QtWidgets.QMainWindow):
         # connect signal
         self.save_csv_button.clicked.connect(self._save_to_csv)
 
-        # this label currently prevents resizing of the first column. Shall be adapted in the future
-        # master_layout.addWidget(text_label, 0, 1)
-        master_layout.setColumnStretch(0, 1)
-        master_layout.setRowStretch(1, 1)
-
         master_layout.setColumnMinimumWidth(0, 900)
-        master_layout.setColumnMinimumWidth(1, 450)
-        master_layout.setRowMinimumHeight(1, 500)
-        master_layout.addWidget(self.data_plt, 1, 0)
-        master_layout.addWidget(self.hist_plt, 1, 1)
+        master_layout.setRowMinimumHeight(2, 500)
+
+        self.time_series_plot_label = QLabel(
+            "Click and drag to select data using the mouse.")
+        self.time_series_plot_label.setFixedHeight(50)
+        self.hist_plot_label = QLabel(
+            "Histogram of all selected data.")
+        master_layout.addWidget(self.time_series_plot_label, 1, 0)
+        master_layout.addWidget(self.hist_plot_label, 1, 1)
+        master_layout.addWidget(self.data_plt, 2, 0)
+        master_layout.addWidget(self.hist_plt, 2, 1)
         master_layout.setColumnStretch(1, 0)
 
         button_grid_layout = QtWidgets.QGridLayout()
@@ -83,8 +81,8 @@ class MainWindow(QtWidgets.QMainWindow):
                                      alignment=QtCore.Qt.AlignRight)
         button_grid = QtWidgets.QWidget()
         button_grid.setLayout(button_grid_layout)
-        master_layout.addWidget(button_grid, 2, 1)
-        master_layout.setRowStretch(2, 0)
+        master_layout.addWidget(button_grid, 3, 1)
+        master_layout.setRowStretch(2, 1)
 
         widget = QtWidgets.QWidget()
         widget.setLayout(master_layout)
@@ -95,6 +93,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def on_region_select_callback(self, min_x_val, max_x_val):
         # self.data_plt.canvas.subplot_axes[0].set_xlim([min_x_val, max_x_val])
         cropped_df = self.crop_df(min_x_val, max_x_val)
+        self.hist_plot_label.setText("Histogram of currently selected data.")
         self.hist_plt.plot(cropped_df)
         dialog_window = ConfirmSelectionWindow()
         selection_accepted = dialog_window.exec_()
@@ -109,7 +108,11 @@ class MainWindow(QtWidgets.QMainWindow):
             self.save_csv_button.setEnabled(True)
             self.data_plt.update_selection_visualitation(
                 self.selection_list[-1])
+        if self.cropped_data_df.empty:
+            self.hist_plt.clear()
+        else:
             self.hist_plt.plot(self.cropped_data_df)
+        self.hist_plot_label.setText("Histogram of all selected data.")
 
         return
 

--- a/src/main_window.py
+++ b/src/main_window.py
@@ -34,6 +34,8 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.data_df = data_df
         self.cropped_data_df = pd.DataFrame()
+        # list of selected tuples (start_index, end_index)
+        self.selection_list = []
 
         # Prepare vertical col name and drop it from the plot config dict
         self.x_axis_col = plot_config_dict["x_axis_col"]
@@ -150,17 +152,22 @@ class MainWindow(QtWidgets.QMainWindow):
 
         if selection_accepted:
             print("selection accepted and added: ", min_x_val, max_x_val)
+            self.selection_list.append({"start": min_x_val, "end": max_x_val})
             cropped_df["old_index"] = copy.deepcopy(cropped_df.index)
             self.cropped_data_df = pd.concat(
                 [self.cropped_data_df, cropped_df])
             self.cropped_data_df = self.cropped_data_df.reset_index(drop=True)
             self.save_csv_button.setEnabled(True)
+            self.data_plt.update_selection_visualitation(
+                self.selection_list[-1])
+            self.data_plt.canvas.draw()
+            self.update_hist_plot(self.data_df)
 
         return
 
     def crop_df(self, x_start, x_end):
         cropped_df = self.data_df[(self.x_axis_data >=
-                                  x_start) & (self.x_axis_data <= x_end)]
+                                   x_start) & (self.x_axis_data <= x_end)]
         # cropped_df = cropped_df[]
         return cropped_df
 

--- a/src/mpl_widget.py
+++ b/src/mpl_widget.py
@@ -34,3 +34,8 @@ class MplWidget(QWidget):
         # self.canvas.axes = self.canvas.figure.add_subplot(111)
 
         self.setLayout(vertical_layout)
+
+    def update_selection_visualitation(self, selection: dict):
+        for subplot in self.canvas.subplot_axes:
+            subplot.axvspan(selection["start"], selection["end"],
+                            facecolor='grey', alpha=0.3)

--- a/src/mpl_widget.py
+++ b/src/mpl_widget.py
@@ -1,5 +1,5 @@
-__author__ = "Manuel Galliker"
-__maintainer__ = "Manuel Galliker"
+__author__ = "Manuel Yves Galliker"
+__maintainer__ = "Manuel Yves Galliker"
 __license__ = "Apache-2.0"
 
 from matplotlib.figure import Figure
@@ -9,9 +9,9 @@ from PyQt5.QtWidgets import QVBoxLayout, QWidget
 
 class MplWidget(QWidget):
 
-    def __init__(self, parent=None, subplot_count=1):
+    def __init__(self, parentWindow=None, subplot_count=1):
 
-        QWidget.__init__(self, parent)
+        QWidget.__init__(self, parentWindow)
 
         self.canvas = FigureCanvas(Figure())
 
@@ -31,11 +31,4 @@ class MplWidget(QWidget):
                     subplot_count, 1, i+1, sharex=ax1)
                 self.canvas.subplot_axes.append(curr_ax)
 
-        # self.canvas.axes = self.canvas.figure.add_subplot(111)
-
         self.setLayout(vertical_layout)
-
-    def update_selection_visualitation(self, selection: dict):
-        for subplot in self.canvas.subplot_axes:
-            subplot.axvspan(selection["start"], selection["end"],
-                            facecolor='grey', alpha=0.3)

--- a/src/time_series_data_plot_widget.py
+++ b/src/time_series_data_plot_widget.py
@@ -52,3 +52,5 @@ class TimeSeriesDataPlotWidget(DataFramePlotWidget):
         for subplot in self.canvas.subplot_axes:
             subplot.axvspan(selection["start"], selection["end"],
                             facecolor='grey', alpha=0.3)
+        self.canvas.draw()
+        return

--- a/src/time_series_data_plot_widget.py
+++ b/src/time_series_data_plot_widget.py
@@ -43,7 +43,7 @@ class TimeSeriesDataPlotWidget(DataFramePlotWidget):
             for topic in subplot_topics_list:
                 self.canvas.subplot_axes[i].plot(
                     df[self.x_axis_col], df[topic], label=topic)
-                self.canvas.subplot_axes[i].legend()
+                self.canvas.subplot_axes[i].legend(loc='lower right')
 
         self.canvas.draw()
         return

--- a/src/time_series_data_plot_widget.py
+++ b/src/time_series_data_plot_widget.py
@@ -1,0 +1,54 @@
+__author__ = "Manuel Yves Galliker"
+__maintainer__ = "Manuel Yves Galliker"
+__license__ = "Apache-2.0"
+
+try:
+    from src.dataframe_plot_widget import DataFramePlotWidget
+except:
+    from visual_dataframe_selector.src.dataframe_plot_widget import DataFramePlotWidget
+
+from matplotlib.widgets import SpanSelector
+import pandas as pd
+from overrides import override
+
+
+class TimeSeriesDataPlotWidget(DataFramePlotWidget):
+    def __init__(self, plot_config_dict: dict, parentWindow):
+        super(TimeSeriesDataPlotWidget, self).__init__(
+            plot_config_dict, parentWindow)
+        self.setup_span(parentWindow)
+
+    def setup_span(self, parentWindow):
+        for i in range(self.subplot_count):
+            self.canvas.subplot_axes[i].span = SpanSelector(
+                self.canvas.subplot_axes[i],
+                onselect=parentWindow.on_region_select_callback,
+                direction="horizontal",
+                minspan=1,
+                useblit=True,
+                button=[1],
+                props={"facecolor": "green", "alpha": 0.3}
+            )
+
+    @override
+    def plot(self, df: pd.DataFrame):
+        x_axis_data = df[self.x_axis_col]
+        x_start = x_axis_data.iloc[0]
+        x_end = x_axis_data.iloc[-1]
+        self.canvas.subplot_axes[0].set_xlim([x_start, x_end])
+
+        for i in range(self.subplot_count):
+            subplot_key = self.subplot_keys[i]
+            subplot_topics_list = self.plot_config_dict[subplot_key]
+            for topic in subplot_topics_list:
+                self.canvas.subplot_axes[i].plot(
+                    df[self.x_axis_col], df[topic], label=topic)
+                self.canvas.subplot_axes[i].legend()
+
+        self.canvas.draw()
+        return
+
+    def update_selection_visualitation(self, selection: dict):
+        for subplot in self.canvas.subplot_axes:
+            subplot.axvspan(selection["start"], selection["end"],
+                            facecolor='grey', alpha=0.3)

--- a/test_visual_dataframe_selector.py
+++ b/test_visual_dataframe_selector.py
@@ -1,5 +1,5 @@
-__author__ = "Manuel Galliker"
-__maintainer__ = "Manuel Galliker"
+__author__ = "Manuel Yves Galliker"
+__maintainer__ = "Manuel Yves Galliker"
 __license__ = "Apache-2.0"
 
 import pandas as pd


### PR DESCRIPTION
This PR contains the following improvements:
- The range of data that has already been selected in now indicated with a grey span box. this was a feature request from #6 
- The histogram plot on the right is now empty in the beginning and shows either the distribution of the currently selected data or the distribution of all selected data.
- The architecture is improved by encapsulating the functionality and operated on members of the time series plot (left) and the histogram plot (right) into their own classes. 
- UI/UX improvement by adding labels above each plot describing the functionality of each plot
- Adaption of the README to account for changes above

@Jaeyoung-Lim please let me know what you think! Is the new UI more intuitive now?

![Screenshot from 2023-03-05 14-11-10](https://user-images.githubusercontent.com/18735094/222972756-e84281df-8441-409d-a6b5-0eda88d1b7d5.png)
